### PR TITLE
Allow imports with 'bad' file basepaths

### DIFF
--- a/parse/resolver.go
+++ b/parse/resolver.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"regexp"
 )
 
 // Resolver assigns unique file-local import names ("nicknames") to packages
@@ -47,7 +48,11 @@ func (m mapResolver) Resolve(local, typePath string) string {
 		return typ // basic type; nothing to do!
 	}
 
-	natural := filepath.Base(impPath)
+	raw_natural := filepath.Base(impPath)
+	// Handle import paths that contain disallowed characters such as go-jira, and
+	// ldap.v2
+	re := regexp.MustCompile(`[-_\.]`)
+	natural := re.ReplaceAllString(raw_natural,``)
 	if natural == local {
 		return typ // type exists locally; no dot prefix
 	}


### PR DESCRIPTION
When using a package that has a base filepath that includes a reserved character such as a hypen, or a dot, the import nickname inherits that, making the generated mock file impossible to compile.

Examples are, "github.com/andygrunwald/go-jira" and "gopkg.in/ldap.v2".

This just squashes those characters, allowing for a legal nickname for imports.

There may be other characters that could/should be added to the regex, but these seemed obvious, and included the real cases I'd encountered.